### PR TITLE
changed `tabler-icons` package to `@tabler/icons`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "fs-extra": "^9.0.1",
         "pascal-case": "^3.1.1",
         "poi": "^12.10.2",
-        "tabler-icons": "^1.15.0",
+        "@tabler/icons": "^1.35.0",
         "vue": "2.6.12",
         "vue-template-compiler": "2.6.12"
     },


### PR DESCRIPTION
Hi! We moved `tabler-icons` package to `@tabler` scope in npm. Old package will be deprecated soon. 

Thank you for your work! :) 