### PR TITLE
fix: Avoid injecting all $data attrs into html

### DIFF
--- a/build.js
+++ b/build.js
@@ -22,6 +22,7 @@ export default {
         const attrs = this.$data.attrs || {};
 
         const allAttrs = {
+            ...this.$attrs,
             width: attrs.width || size,
             height: attrs.height || size,
         }

--- a/build.js
+++ b/build.js
@@ -20,8 +20,8 @@ export default {
     render() {
         const size = this.$props.size + 'px';
         const attrs = this.$data.attrs || {};
+
         const allAttrs = {
-            ...this.$data,
             width: attrs.width || size,
             height: attrs.height || size,
         }


### PR DESCRIPTION
It solves #20 - Changes the svg injected attributes for `$attrs` instead of `$data`.