### PR TITLE
fix GitHub workflow badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tabler Icons as Vue 3 components
 
 ![NPM](https://img.shields.io/npm/v/vue-tabler-icons)
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/alex-oleshkevich/vue-tabler-icons/Test)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/alex-oleshkevich/vue-tabler-icons/test.yml?branch=master)
 ![GitHub](https://img.shields.io/github/license/alex-oleshkevich/vue-tabler-icons)
 ![NPM - Downloads](https://img.shields.io/npm/dm/vue-tabler-icons)
 


### PR DESCRIPTION
fix GitHub workflow badge URL.

See https://github.com/badges/shields/issues/8671

> You need to update your badge URL from
> https://img.shields.io/github/workflow/status/<user>/<repo>/Run%20Tests
> to
> https://img.shields.io/github/actions/workflow/status/<user>/<repo>/test.yml?branch=main